### PR TITLE
Fix schedule syntax

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: Mirror GitLab plugins to GitHub
 
 on:
   schedule:
-    - cron: 0 0,12 0 0 0
+    - cron: 0 0,12 * * *
 
 jobs:
   mirror-gitlab-plugins:


### PR DESCRIPTION
This job is intended to run at 00:00 and 12:00 UTC everyday. But it was
scheduled to run on the 0th day of the 0th months at those times
instead. Replacing the zeros with asterisks corrects the schedule.