### PR TITLE
Use GitHub API call to confirm if repo exists

### DIFF
--- a/mirror-plugins
+++ b/mirror-plugins
@@ -19,7 +19,7 @@ class Plugin
   end
 
   def github_repo_exists?
-    system("git ls-remote -q #{construct_github_https_url} >/dev/null 2>&1")
+    `curl -s -w "%{http_code}" -I -H "Authorization: token #{ENV.fetch("GH_ACCOUNT_TOKEN")}" https://api.github.com/repos/#{ENV.fetch("GH_ORG_NAME")}/#{@project.path} -o /dev/null` == "200"
   end
 
   def gitlab_project_empty?


### PR DESCRIPTION
Whilst using `git ls-remote` works locally for checking if a repo exists, it 
is failing in the context of GitHub actions, and always returning an error. 
This means the script always thinks the repo doesn't already exist, and 
then tries (and fails) to create it again.

I'm not entirely sure why this is, but I think it may be because we're
already inside a git repo (this one, checked out by the checkout
action), and that's causing a conflict.

So instead, let's call the API. If we get a 200 response, the repo
we're looking for exists, if we get anything else, it doesn't.

Because we just want the response code, we're using CURL to call the API
here, rather than `gh api`.