### PR TITLE
Run sync every hour

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: Mirror GitLab plugins to GitHub
 
 on:
   schedule:
-    - cron: 0 0,12 * * *
+    - cron: 0 0-23 * * *
 
 jobs:
   mirror-gitlab-plugins:


### PR DESCRIPTION
Now this task is running reliably, it is typically only taking 10-15
mins per run. Therefore, let's run it much more frequently to ensure
everything is up to date.

This is a public repo, so we won't burn through any GitHub minutes
allocation by doing this.