### PR TITLE
Use v1.0.7 of keepalive-workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,7 +44,7 @@ jobs:
           ./mirror-plugins
 
       - name: Keep workflow alive
-        uses: dxw/keepalive-workflow@master
+        uses: gautamkrishnar/keepalive-workflow@c85efc9567a3dadb9b9d4e116aa891f76c0ef7e6
         with:
           commit_message: Automated commit by Keepalive Workflow to keep the repository active [skip ci]
           committer_username: dxw-govpress-tools


### PR DESCRIPTION
The previous version we were using (1.06) didn't push the commit it
generated to the repo, so therefore didn't generate the necessary
activity to stop the repo being marked as inactive. This latest version
fixes that issue (see
https://github.com/gautamkrishnar/keepalive-workflow/pull/3).

I've also switched to using the upstream version, rather than our fork.
If we pin to a specific commit we're happy with (as I've done here),
this is equally safe.