### PR TITLE
Feature/alert slack on workflow failure

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,3 +49,12 @@ jobs:
           commit_message: Automated commit by Keepalive Workflow to keep the repository active [skip ci]
           committer_username: dxw-govpress-tools
           committer_email: team+govpress-tools@govpress.com
+      
+      - name: Alert Slack if failure
+        if: ${{ failure() }}
+        uses: slackapi/slack-github-action@v1.23.0
+        with:
+          channel-id: ${{ secrets.SLACK_CHANNEL_ID }}  # Slack channel id to post message
+          slack-message: "The scheduled task to mirror GitLab plugins to GitHub has failed. Check the workflow history for more information: https://github.com/dxw-wordpress-plugins/mirror-gitlab-plugins/actions/workflows/main.yml, and see the documentation for possible causes: https://github.com/dxw-wordpress-plugins/mirror-gitlab-plugins/blob/main/README.md"
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@ Having both the plugins and application repos hosted on GitHub will make it much
 
 The mirrored repos hosted on GitHub are intended to be read-only, and we will still be deploying from the GitLab-hosted versions.
 
+## Potential causes of workflow failure
+
+Occasionally, the action will fail. There are a couple of commons causes for this:
+
+1. The code assumes that the default branch for GitLab repos will match the value of the `DEFAULT_BRANCH_NAME` secret (currently set to `master`). If this is not the case (or if the `DEFAULT_BRANCH_NAME` branch does exist, but is not the default branch), the workflow may fail. Potential fix: make the expected branch the default for the GitLab repo in question.
+
+1. The connection to GitLab times out, or returns some other unexpected response. This is normally a temporary glitch, and will resolve itself on the next workflow run.
+
 ## Testing locally
 
 You can test the action locally using [act](https://github.com/nektos/act).

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ The mirrored repos hosted on GitHub are intended to be read-only, and we will st
 
 ## Potential causes of workflow failure
 
-Occasionally, the action will fail. There are a couple of commons causes for this:
+Occasionally, the action will fail. When it does so, it will alert the GovPress Team channel (set by the `SLACK_CHANNEL_ID` secret) via the GovPress Tools Slackbot (set via `SLACK_BOT_TOKEN`).
+
+There are a couple of commons causes for failures:
 
 1. The code assumes that the default branch for GitLab repos will match the value of the `DEFAULT_BRANCH_NAME` secret (currently set to `master`). If this is not the case (or if the `DEFAULT_BRANCH_NAME` branch does exist, but is not the default branch), the workflow may fail. Potential fix: make the expected branch the default for the GitLab repo in question.
 


### PR DESCRIPTION
This PR amends the workflow so that it will alert Slack if it fails (last failure was 4 months ago, so this should generate a significant amount of noise), and adds some documentation on common causes of failure.