### PR TITLE
Add a dry run mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,5 @@ GH_ACCOUNT_TOKEN=github-account-token
 GITLAB_ACCOUNT_USERNAME=gitlab-account-username
 # The access token for the GitLab account used to clone from GitLab (needs read api & read repo access)
 GITLAB_ACCOUNT_TOKEN=gitlab-account-token
+# Boolean to indicate dry_run mode for local dev use - remove or set to false in prod
+DRY_RUN=true

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Install act:
 brew install act
 ```
 
-Then copy the `.env.example` file to `.env`, and populate it with the appropriate values (you can use the values from the service accounts in 1password if needed).
+Then copy the `.env.example` file to `.env`, and populate it with the appropriate values (you can use the values from the service accounts in 1password if needed). In particular, set `DRY_RUN=true`, so that no real changes are made.
 
 Then run the action with:
 
@@ -33,7 +33,7 @@ Then run the action with:
 act -j mirror-gitlab-plugins --secret-file .env
 ```
 
-NOTE: this will actually start the mirroring process off for real, and there are over 700 plugins to be mirrored! So you may want to tweak lines 58 & 60 of the `mirror-plugins` script to reduce that number, e.g.:
+NOTE: if you don't set `DRY_RUN=true`, this will actually start the mirroring process off for real, and there are over 700 plugins to be mirrored! If you mean to do this (e.g. to test against a small batch of real data) you may want to tweak lines 58 & 60 of the `mirror-plugins` script to reduce that number, e.g.:
 
 ```
 projects = Gitlab.group_projects(ENV['GITLAB_WORDPRESS_PLUGINS_GROUP_ID'], per_page: 10)

--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ Then run the action with:
 act -j mirror-gitlab-plugins --secret-file .env
 ```
 
+If you're using a machine with an ARM-based processor, you may need to do:
+
+```
+act -j mirror-gitlab-plugins --secret-file .env --container-architecture linux/amd64
+```
+
 NOTE: if you don't set `DRY_RUN=true`, this will actually start the mirroring process off for real, and there are over 700 plugins to be mirrored! If you mean to do this (e.g. to test against a small batch of real data) you may want to tweak lines 58 & 60 of the `mirror-plugins` script to reduce that number, e.g.:
 
 ```

--- a/mirror-plugins
+++ b/mirror-plugins
@@ -58,9 +58,17 @@ class Plugin
   end
 end
 
+def dry_run?
+  ENV["DRY_RUN"] == "true"
+end
+
 Gitlab.configure do |config|
   config.endpoint = ENV.fetch("GITLAB_API_ENDPOINT")
   config.private_token = ENV.fetch("GITLAB_ACCOUNT_TOKEN")
+end
+
+if dry_run?
+  puts "-- Dry run mode --"
 end
 
 projects = Gitlab.group_projects(ENV.fetch("GITLAB_WORDPRESS_PLUGINS_GROUP_ID"), per_page: 50)
@@ -88,7 +96,15 @@ projects.auto_paginate do |project|
       next project
     end
     puts "...creating and mirroring to it now"
-    plugin.create_github_repo
+    if dry_run?
+      puts "-- Dry run mode, no repo creation taking place --"
+    else
+      plugin.create_github_repo
+    end
   end
-  plugin.update_github_mirror
+  if dry_run?
+    puts "-- Dry run mode, no repo mirroring taking place --"
+  else
+    plugin.update_github_mirror
+  end
 end


### PR DESCRIPTION
This adds the ability to run the command in dry-run mode by setting an env var of `DRY_RUN=true`.

Note that I've used a different way of accessing the env var here - `ENV['var_name']` rather than `ENV.fetch('var_name')` as the latter will error if the variable doesn't exist, whereas the former will just return a default value of false.

## How to test

1. Copy the `env.example` file to `.env` and populate as follows:
   ```
   GITLAB_API_ENDPOINT=https://git.govpress.com/api/v4
   GITLAB_WORDPRESS_PLUGINS_GROUP_ID=71
   GH_ORG_NAME=dxw-wordpress-plugins
   DEFAULT_BRANCH_NAME=master
   GH_TEAM_ID=1234567 #this value will not be used so a random integer will do
   GH_ACCOUNT_USERNAME=dxw-govpress-tools
   GH_ACCOUNT_TOKEN=[the "mirror-gitlab-plugins" API token from the 1password entry for the github govpress tools service account]
   GITLAB_ACCOUNT_USERNAME=govpress-tools
   GITLAB_ACCOUNT_TOKEN=[the read-only API token from the 1password entry for the gitlab govpress tools service account]
   DRY_RUN=true
   ```
1. Install [act](https://github.com/nektos/act) for testing GitHub actions locally: `brew install act`
1. Run the action: `act -j mirror-gitlab-plugins --secret-file .env`. It should run successfully, outputting that it is in dry run mode, and what actions it would take, without performing those actions.