### PR TITLE
Feature/major version tags

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,3 +22,5 @@ GITLAB_ACCOUNT_USERNAME=gitlab-account-username
 GITLAB_ACCOUNT_TOKEN=gitlab-account-token
 # Boolean to indicate dry_run mode for local dev use - remove or set to false in prod
 DRY_RUN=true
+# Boolean to force all repos to re-sync, regardless of whether they are already fully mirrored. Can be used if e.g. we wish to add additional tags during the mirror process. Should generally be set to false, or removed altogether
+FORCE_UPDATE=false

--- a/mirror-plugins
+++ b/mirror-plugins
@@ -56,6 +56,7 @@ class Plugin
     if $?.exitstatus == 0
       split_tag = full_tag.split(".")
       major_tag = split_tag[0]
+      major_tag.prepend("v") unless major_tag.start_with?("v")
       puts "Tagging latest commit with major version tag of #{major_tag}"
       `git -C #{@project.path}.git tag -f #{major_tag}`
     else

--- a/mirror-plugins
+++ b/mirror-plugins
@@ -77,6 +77,10 @@ def dry_run?
   ENV["DRY_RUN"] == "true"
 end
 
+def force_update?
+  ENV["FORCE_UPDATE"] == "true"
+end
+
 Gitlab.configure do |config|
   config.endpoint = ENV.fetch("GITLAB_API_ENDPOINT")
   config.private_token = ENV.fetch("GITLAB_ACCOUNT_TOKEN")
@@ -101,7 +105,7 @@ projects.auto_paginate do |project|
     end
     if plugin.repos_in_sync?
       puts "...and is in sync"
-      next project
+      next project unless force_update?
     end
     puts "... mirroring to it now"
   else

--- a/mirror-plugins
+++ b/mirror-plugins
@@ -51,8 +51,22 @@ class Plugin
   def update_github_mirror
     puts "Cloning the gitlab source..."
     `git clone --mirror #{construct_gitlab_https_url}`
+    puts "Generating major version tag..."
+    full_tag = `git -C #{project.path}.git describe --tags --abbrev=0`
+    if $?.exitstatus == 0
+      split_tag = full_tag.split(".")
+      major_tag = split_tag[0]
+      puts "Tagging latest commit with major version tag of #{major_tag}"
+      `git -C #{@project.path}.git tag -f #{major_tag}`
+    else
+      puts "No tag information found"
+    end
     puts "Updating the github repo..."
-    `git -C #{@project.path}.git push --mirror #{construct_github_https_url}`
+    if dry_run?
+      puts "-- Dry run mode, no repo mirroring taking place --"
+    else
+      `git -C #{@project.path}.git push --mirror #{construct_github_https_url}`
+    end
     # clean up
     `rm -rf #{@project.path}.git`
   end
@@ -102,9 +116,5 @@ projects.auto_paginate do |project|
       plugin.create_github_repo
     end
   end
-  if dry_run?
-    puts "-- Dry run mode, no repo mirroring taking place --"
-  else
-    plugin.update_github_mirror
-  end
+  plugin.update_github_mirror
 end


### PR DESCRIPTION
This PR:

1) Amends the mirroring script so that it tags the latest commit on a plugin's GitHub `master` branch with a major version tag, derived from the full version tag that is already associated with that same commit in the GitLab source repo. e.g. if the latest commit to `master` is tagged `v6.3.2` on GitLab, a `v6` tag will be added to that commit on GitHub. 
   If the version tag on GitLab lacks the preceding `v` (e.g. a tag of just `6.3.2`) a `v` will be added to the major version tag (so `v6` would still be the result).
   If no tag is associated with the latest commit on GitLab, no additional tag will be added, and the repo will be mirrored as-is.
2. Adds a `FORCE_UPDATE` environment variable that can be used to re-mirror all repos, even if they are already in sync. This will be particularly useful if we want to refresh git metadata on all repos, including those where the latest commits on GitHub are already in sync with their GitLab counterparts (and therefore would not be updated in a standard run).
   For instance, currently we want to be able to generate major version tags for *all* repos, not just those that have received an update since this workflow last ran. Setting `FORCE_UPDATE` to true will enable us to do this. We will then be able to remove the `FORCE_UPDATE` secret, and the workflow will return to its normal behaviour, of only syncing plugin repos that have received an update since the last workflow run.

## How to test

1. Copy the env.example file to .env and populate as follows:
   ```
   GITLAB_API_ENDPOINT=https://git.govpress.com/api/v4
   GITLAB_WORDPRESS_PLUGINS_GROUP_ID=71
   GH_ORG_NAME=dxw-wordpress-plugins
   DEFAULT_BRANCH_NAME=master
   GH_TEAM_ID=1234567 #this value will not be used so a random integer will do
   GH_ACCOUNT_USERNAME=dxw-govpress-tools
   GH_ACCOUNT_TOKEN=[the "mirror-gitlab-plugins" API token from the 1password entry for the github govpress tools service account]
   GITLAB_ACCOUNT_USERNAME=govpress-tools
   GITLAB_ACCOUNT_TOKEN=[the read-only API token from the 1password entry for the gitlab govpress tools service account]
   DRY_RUN=true
   FORCE_UPDATE=true
   ```
1. Install [act](https://github.com/nektos/act) for testing GitHub actions locally: brew install act
1. Run the action: `act -j mirror-gitlab-plugins --secret-file .env`. It should run successfully, outputting that it is in dry run mode, and what actions it would take, without performing those actions. It should report that it would sync all repos. It should also report the major version tags it would apply to each repo. If you compare these to the full latest version tags in GitLab, they should correspond.
1. If you remove `FORCE_UPDATE=true` from `.env` and re-run the action, you should see that the action reports that it would only mirror repos that are not currently in sync with their GitLab counterparts.