### PR TITLE
Wordpress mirror maintenance

### DIFF
--- a/.github/workflows/wordpress-mirror.yml
+++ b/.github/workflows/wordpress-mirror.yml
@@ -40,7 +40,7 @@ jobs:
           ./mirror-wordpress-plugins
 
       - name: Keep workflow alive
-        uses: gautamkrishnar/keepalive-workflow@1.1.0
+        uses: gautamkrishnar/keepalive-workflow@2.0.1
         with:
           commit_message: Automated commit by Keepalive Workflow to keep the repository active [skip ci]
           committer_username: dxw-govpress-tools

--- a/mirror-wordpress-plugins
+++ b/mirror-wordpress-plugins
@@ -179,7 +179,7 @@ class PluginLibraryUpdater
 
   def initialize
     @failed_updates = {}
-    @updated_plugins = []
+    @updated_plugins = {}
     @start_time = nil
     @end_time = nil
   end
@@ -206,7 +206,7 @@ class PluginLibraryUpdater
       puts "...mirroring to it now"
       begin
         plugin.update_github_mirror
-        @updated_plugins.push(plugin.slug)
+        @updated_plugins[plugin.slug] = plugin.latest_wordpress_version
       rescue PluginUpdateError => e
         @failed_updates[plugin.slug] = e.message
         plugin.cleanup
@@ -229,15 +229,17 @@ class PluginLibraryUpdater
     return if @updated_plugins.empty?
 
     hrule
-    puts "==> Updated the following #{@updated_plugins.size} plugins:"
-    puts @updated_plugins.join("\n")
+    puts "==> Updated the following #{@updated_plugins.size} plugin(s):"
+    @updated_plugins.each do |name, version|
+      puts "#{name} updated to version #{version}"
+    end
   end
 
   def print_failed_plugin_summary
     return if @failed_updates.empty?
 
     hrule
-    puts "==> Failed to update the following #{@failed_updates.size} plugins:"
+    puts "==> Failed to update the following #{@failed_updates.size} plugin(s):"
     @failed_updates.each do |name, error_message|
       puts
       puts "*** #{name} failed to update with message:"

--- a/mirror-wordpress-plugins
+++ b/mirror-wordpress-plugins
@@ -62,7 +62,7 @@ class Plugin
 
   def update_github_mirror
     puts "==> Cloning the #{@slug} GitHub repo..."
-    `git clone #{@github_https_url} #{@full_path_to_clone}`
+    `git clone #{construct_github_https_url} #{@full_path_to_clone}`
     raise GitError, "Could not clone #{@github_url}" unless $CHILD_STATUS.success?
 
     puts "==> Fetching and extracting latest release from wordpress.org"
@@ -104,6 +104,12 @@ class Plugin
   end
 
   private
+
+  def construct_github_https_url
+    credentials = ENV.fetch("GH_ACCOUNT_USERNAME") + ":" + ENV.fetch("GH_ACCOUNT_TOKEN") + "@"
+    url = "https://github.com/" + ENV.fetch("GH_ORG_NAME") + "/" + @slug + ".git"
+    url.insert(8, credentials)
+  end
 
   def commit_and_tag
     `git -C #{@full_path_to_clone} add -A -f .`


### PR DESCRIPTION
This PR adds three small maintenance changes to the wordpress.org version of the mirror script which is currently running in `dry-run` mode.

#### Update the `keepalive-workflow` workflow

To avoid a deprecation warning about Node.

#### Add version numbers to the updated plugins summary

Previously we just listed the plugins that had been updated. Now we also state which version they were updated to. For example:

    -------------------------------------------------------------
    ==> Updated the following 1 plugin(s):
    category-specific-rss-feed-menu was updated to version v2.3.1

#### Fix log warnings about GitHub authentication

We are consistently seeing errors of this form in the logs:

    fatal: could not read Username for 'https://github.com/': No such device or address

[This log is a good example](https://github.com/dxw-wordpress-plugins/mirror-gitlab-plugins/actions/runs/9123771834/job/25086767304).

Which indicates that logging in with `gh` has not been enough to save the credentials that Git needs to perform actions on private repositories.

In this PR we use the same scheme as the mirror-plugins script to clone via https.

### Testing

Make sure you have a `.env` that matches `.env.wordpress-example` and that `DRY_RUN` is set to `true`, then run:

```shell
./mirror-wordpress-plugins --dry-run
```

You might also want to comment out the lines in the `Plugin.cleanup` method so that you can see the tags and commits that the script created.