### PR TITLE
Add global Git configuration to workflow

### DIFF
--- a/.github/workflows/wordpress-mirror.yml
+++ b/.github/workflows/wordpress-mirror.yml
@@ -29,6 +29,11 @@ jobs:
         run: |
           echo "${{ secrets.GH_ACCOUNT_TOKEN }}" | gh auth login --with-token
 
+      - name: Add global Git configuration
+        run: |
+          git config --global user.email "team+govpress-tools@govpress.com"
+          git config --global user.name "WordPress plugin mirror robot"
+
       - name: Mirror WordPress plugins
         env:
           GH_ACCOUNT_USERNAME: ${{ secrets.GH_ACCOUNT_USERNAME }}


### PR DESCRIPTION
In the scheduled job we are seeing errors of the form:

    Author identity unknown

This doesn't appear in local dev envs, presumably
because developers all have Git fully configured.

This error also does not appear on the GitLab
scheduled jobs, possibly because we clone with
`--mirror` which sets up repositories slightly
differently to a normal clone operation.

This commit adds the small amount of configuration that should be needed to commit, tag and push
from the mirrors.