### PR TITLE
Workaround for bad tags

### DIFF
--- a/.github/workflows/wordpress-mirror.yml
+++ b/.github/workflows/wordpress-mirror.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Ruby setup
         uses: ruby/setup-ruby@v1

--- a/mirror-wordpress-plugins
+++ b/mirror-wordpress-plugins
@@ -119,6 +119,7 @@ class Plugin
     major_tag = split_tag[0]
     major_tag.prepend("v") unless major_tag.start_with?("v")
     `git -C #{@full_path_to_clone} tag #{@latest_wordpress_version}`
+    raise GitError, "Could not create tag #{@latest_wordpress_version}" unless $CHILD_STATUS.success?
     `git -C #{@full_path_to_clone} tag -f #{major_tag}`
   end
 

--- a/mirror-wordpress-plugins
+++ b/mirror-wordpress-plugins
@@ -125,12 +125,12 @@ class Plugin
   def fetch_latest_github_version
     puts("==> Querying GitHub for latest version ...")
     begin
-      latest_github_version = `gh api repos/#{ENV.fetch("GH_ORG_NAME")}/#{@slug}/git/refs/tags --jq '.[].ref' | sort -V | tail -n 1 | cut -d '/' -f 3`
+      latest_github_version = `gh api repos/#{ENV.fetch("GH_ORG_NAME")}/#{@slug}/git/refs/tags --jq '.[].ref' | cut -d '/' -f 3 | grep -Eo "[0-9\.]+" | sort -V | tail -n 1`
     rescue
       # Assume the repo is empty and/or does not have any tags.
       latest_github_version = ""
     end
-    latest_github_version.start_with?("v") ? latest_github_version.strip : "v#{latest_github_version.strip}"
+    "v#{latest_github_version.strip}"
   end
 
   def fetch_latest_wordpress_info


### PR DESCRIPTION
Previously we made an assumption that tags from GitHub repos could be sorted alphabetically.

This fails in the case of login-lockdown which has a latest tag of v2.10 on both GitHub and GitLab, but also has an old tag, vv1.8.1. In this case the script tries to push a "new" tag of v2.10 to GitHub, which already exists, leading to:

    fatal: tag 'v2.10' already exists

The cause of this is that we use `sort -V` to sort semver versions. `sort` assumes that the input lines are file names of the form PREFIX VERSION SUFFIX, where SUFFIX matches the regular expression "(.([A-Za-z~][A-Za-z0-9~]*)?)*", and in this case that assumption fails.

In this PR we correct that by stripping out all alphabetical characters before we sort and compare the tags from the GitHub repo. This is the new algorithm:

      gh api ... --jq '.[].ref'  # Fetch all tags from GitHub
    | cut -d '/' -f 3            # refs/tags/v1.2.3 -> v1.2.3
    | grep -Eo "[0-9\.]+"        # Match only numbers and "."
    | sort -V                    # Sort semver versions
    | tail -n 1                  # Take the last version

This gives the correct result for login-lockdown:

    ==> login-lockdown is v2.10 on WordPress and v2.10 on GitHub
    ...which is already up to date with WordPress.org

This PR also updates the checkout action and raises an exception if `git tag` fails. Previously we ignored these errors, assuming that only operations with remotes were likely to fail.

### Testing

Make sure you have a .env that matches .env.wordpress-example and that DRY_RUN is set to true, then run:

    ./mirror-wordpress-plugins --dry-run

You might also want to comment out the lines in the Plugin.cleanup method so that you can see the tags and commits that the script created.