### PR TITLE
Add topics to repos with api failures

### DIFF
--- a/.env.wordpress-example
+++ b/.env.wordpress-example
@@ -12,3 +12,5 @@ GH_ACCOUNT_TOKEN=github-account-token
 DRY_RUN=true
 # Boolean to force all repos to re-sync, regardless of whether they are already fully mirrored. Can be used if e.g. we wish to add additional tags during the mirror process. Should generally be set to false, or removed altogether
 FORCE_UPDATE=false
+# Edit repository topics, even in dry-run mode. Use to manage repo metadata when not actually pushing to repos.
+FORCE_ANNOTATION=false

--- a/.env.wordpress-example
+++ b/.env.wordpress-example
@@ -14,3 +14,5 @@ DRY_RUN=true
 FORCE_UPDATE=false
 # Edit repository topics, even in dry-run mode. Use to manage repo metadata when not actually pushing to repos.
 FORCE_ANNOTATION=false
+# Set repository topics on repositories that already have the 'skip-mirror' topic set, rather than ignoring them.
+ANNOTATE_SKIPPED_REPOS=false

--- a/.github/workflows/wordpress-mirror.yml
+++ b/.github/workflows/wordpress-mirror.yml
@@ -42,6 +42,7 @@ jobs:
           DRY_RUN: true
           FORCE_UPDATE: false
           FORCE_ANNOTATION: false
+          ANNOTATE_SKIPPED_REPOS: false
         run: |
           ./mirror-wordpress-plugins
 

--- a/.github/workflows/wordpress-mirror.yml
+++ b/.github/workflows/wordpress-mirror.yml
@@ -41,6 +41,7 @@ jobs:
           GH_ORG_NAME: ${{ secrets.GH_ORG_NAME }}
           DRY_RUN: true
           FORCE_UPDATE: false
+          FORCE_ANNOTATION: false
         run: |
           ./mirror-wordpress-plugins
 

--- a/mirror-wordpress-plugins
+++ b/mirror-wordpress-plugins
@@ -82,18 +82,18 @@ class PluginUpdater
   end
 
   def annotate_github_mirror(value, prefix = "")
-    new_topic = RepositoryTopic.new(value, prefix)
+    new_topic = RepositoryTopic.new(value, @repo, prefix)
     if @topics.include? new_topic.value
       puts "==> @slug already has a #{new_topic.value} topic set"
     end
     if !prefix.empty?
       @topics.each do |topic|
         if topic.start_with?("#{prefix}:")
-          RepositoryTopic.new(topic.split(":")[1], prefix).remove_from_repo(@repo)
+          RepositoryTopic.new(topic.split(":")[1], @repo, prefix).remove_from_repo
         end
       end
     end
-    new_topic.add_to_repo(@repo)
+    new_topic.add_to_repo
   end
 
   def update_github_mirror
@@ -227,30 +227,31 @@ end
 class RepositoryTopic
   @@separator = ":".freeze
 
-  attr_reader :value
+  attr_reader :value, :repo
 
-  def initialize(text, prefix = "")
+  def initialize(text, repo, prefix = "")
     clean_text = text.to_s.gsub(/[^a-z0-9\-\s]/i, "").downcase.gsub(/\s+/, "-")
     @value = prefix.nil? || prefix.empty? ? clean_text : "#{prefix}#{@@separator}#{clean_text}"
+    @repo = repo
   end
 
-  def add_to_repo(repo)
+  def add_to_repo
     puts "==> Adding topic #{@value} to repo..."
-    edit_repo(repo, "add")
+    edit_repo("add")
   end
 
-  def remove_from_repo(repo)
+  def remove_from_repo
     puts "==> Removing topic #{@value} from repo..."
-    edit_repo(repo, "remove")
+    edit_repo("remove")
   end
 
   private
 
-  def edit_repo(repo, action)
+  def edit_repo(action)
     if dry_run? && !force_annotation?
       puts "... -- Dry run mode, no repo edits taking place --"
     else
-      `gh repo edit #{repo} --#{action}-topic #{@value}`
+      `gh repo edit #{@repo} --#{action}-topic #{@value}`
     end
   end
 end

--- a/mirror-wordpress-plugins
+++ b/mirror-wordpress-plugins
@@ -34,8 +34,10 @@ end
 class GitError < PluginUpdateError
 end
 
-# A Plugin is a GitHub repository that mirrors a plugin from wordpress.org.
-class Plugin
+# A PluginUpdater is a representation of a GitHub repository that mirrors a
+# plugin from wordpress.org. PluginUpdaters are responsible for updating
+# their related repositories.
+class PluginUpdater
   attr_reader :slug, :github_url, :default_branch, :topics, :full_path_to_clone, :wordpress_api_url, :wordpress_download_link,
     :latest_github_version, :latest_wordpress_version
 
@@ -183,8 +185,8 @@ class Plugin
 end
 
 # Get information about organisation plugins from GitHub and transform into an
-# array of Plugin objects.
-class PluginBuilder
+# array of PluginUpdater objects.
+class PluginUpdaterBuilder
   @@max_repos_in_library = 99_999 # Effectively unlimited.
 
   def initialize
@@ -197,7 +199,7 @@ class PluginBuilder
     projects.each do |project|
       json_topics = project["repositoryTopics"]
       topics = json_topics.nil? ? [] : json_topics.map { |hash| hash["name"] }
-      plugin = Plugin.new(project["name"], project["url"], project["defaultBranchRef"], topics)
+      plugin = PluginUpdater.new(project["name"], project["url"], project["defaultBranchRef"], topics)
       next project if plugin.nil?
       @plugins.push(plugin)
     end
@@ -226,7 +228,7 @@ class PluginLibraryUpdater
 
   def update
     @start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-    plugins = PluginBuilder.new.build
+    plugins = PluginUpdaterBuilder.new.build
     plugins.each do |plugin|
       hrule
       puts "==> Checking status of #{plugin.slug}..."

--- a/mirror-wordpress-plugins
+++ b/mirror-wordpress-plugins
@@ -300,7 +300,7 @@ class PluginLibraryUpdater
       hrule
       puts "==> Checking status of #{plugin.slug}..."
       begin
-        if plugin.topics.include? "skip-mirror"
+        if plugin.topics.include? "skip-mirror" && !annotate_skipped_repos?
           @skipped_plugins.push(plugin.slug)
           puts "==> Skipping..."
           next
@@ -321,7 +321,7 @@ class PluginLibraryUpdater
       end
       puts "...mirroring to it now"
       begin
-        plugin.update_github_mirror
+        plugin.update_github_mirror unless plugin.topics.include? "skip-mirror"
         @updated_plugins[plugin.slug] = plugin.latest_wordpress_version
       rescue PluginUpdateError => e
         @failed_updates[plugin.slug] = e.message
@@ -381,6 +381,10 @@ end
 
 def dry_run?
   ENV["DRY_RUN"] == "true"
+end
+
+def annotate_skipped_repos?
+  ENV["ANNOTATE_SKIPPED_REPOS"] == "true"
 end
 
 def force_update?

--- a/mirror-wordpress-plugins
+++ b/mirror-wordpress-plugins
@@ -41,8 +41,8 @@ class PluginUpdater
   attr_reader :slug, :repo, :github_url, :default_branch, :topics, :full_path_to_clone, :wordpress_api_url, :wordpress_download_link,
     :latest_github_version, :latest_wordpress_version
 
-  @@wordpress_api_url = "https://api.wordpress.org/plugins/info/1.0/"
-  @@skip_mirror_topic = "skip-mirror"
+  @@wordpress_api_url = "https://api.wordpress.org/plugins/info/1.0/".freeze
+  @@skip_mirror_topic = "skip-mirror".freeze
 
   def initialize(name, github_url, default_branch, topics)
     @slug = name
@@ -225,7 +225,7 @@ end
 # These are not documented and not in a consistent format. So, we remove
 # any punctuation and replace spacing with dashes before storing the string.
 class RepositoryTopic
-  @@separator = ":"
+  @@separator = ":".freeze
 
   attr_reader :value
 

--- a/mirror-wordpress-plugins
+++ b/mirror-wordpress-plugins
@@ -38,13 +38,15 @@ end
 # plugin from wordpress.org. PluginUpdaters are responsible for updating
 # their related repositories.
 class PluginUpdater
-  attr_reader :slug, :github_url, :default_branch, :topics, :full_path_to_clone, :wordpress_api_url, :wordpress_download_link,
+  attr_reader :slug, :repo, :github_url, :default_branch, :topics, :full_path_to_clone, :wordpress_api_url, :wordpress_download_link,
     :latest_github_version, :latest_wordpress_version
 
   @@wordpress_api_url = "https://api.wordpress.org/plugins/info/1.0/"
+  @@skip_mirror_topic = "skip-mirror"
 
   def initialize(name, github_url, default_branch, topics)
     @slug = name
+    @repo = "#{ENV.fetch("GH_ORG_NAME")}/#{@slug}"
     @github_url = github_url
     @github_https_url = "#{@github_url}.git"
     @default_branch = default_branch
@@ -73,6 +75,21 @@ class PluginUpdater
     wordpress_semver = @latest_wordpress_version.start_with?("vv") ? Gem::Version.new(@latest_wordpress_version[2..]) : Gem::Version.new(@latest_wordpress_version[1..])
     github_semver = @latest_github_version.start_with?("vv") ? Gem::Version.new(@latest_github_version[2..]) : Gem::Version.new(@latest_github_version[1..])
     wordpress_semver > github_semver
+  end
+
+  def annotate_github_mirror(value, prefix = "")
+    new_topic = RepositoryTopic.new(value, prefix)
+    if @topics.include? new_topic.value
+      puts "==> @slug already has a #{new_topic.value} topic set"
+    end
+    if !prefix.empty?
+      @topics.each do |topic|
+        if topic.start_with?("#{prefix}:")
+          RepositoryTopic.new(topic.split(":")[1], prefix).remove_from_repo(@repo)
+        end
+      end
+    end
+    new_topic.add_to_repo(@repo)
   end
 
   def update_github_mirror
@@ -156,8 +173,13 @@ class PluginUpdater
     rescue JSON::ParserError => e
       raise WordPressPluginApiError, e.message
     end
-    # Whippet Racetrack error message here was "No plugin info available for <plugin>".
-    raise WordPressPluginJSONContainsError.new(plugin_info["error"].to_s, plugin_info["reason"].to_s) if plugin_info.key?("error")
+    if plugin_info.key?("error")
+      annotate_github_mirror(@@skip_mirror_topic)
+      annotate_github_mirror(plugin_info["error"], "status")
+      annotate_github_mirror(plugin_info["reason"], "reason") if plugin_info.key?("reason") && plugin_info["reason"].is_a?(String)
+      # Whippet Racetrack error message here was "No plugin info available for <plugin>".
+      raise WordPressPluginJSONContainsError.new(plugin_info["error"].to_s, plugin_info["reason"].to_s)
+    end
 
     latest_version_no_spaces = plugin_info["version"].tr(" ", "-").to_s
     latest_wordpress_version = latest_version_no_spaces.start_with?("v") ? latest_version_no_spaces : "v#{latest_version_no_spaces}"
@@ -180,6 +202,51 @@ class PluginUpdater
 
         zipfile.extract(entry, destination_path)
       end
+    end
+  end
+end
+
+# A repository topic is a single piece of metadata displayed on the repo page.
+# This class takes strings, which will usually be from the WordPress API into
+# a repository topic which can be added or removed from a repository.
+#
+# Example error and `reason_text` JSON values include that might be used as
+# topics include:
+#
+#   * closed
+#   * Plugin not found.
+#   * Guideline Violation
+#   * Security Issue
+#
+# These are not documented and not in a consistent format. So, we remove
+# any punctuation and replace spacing with dashes before storing the string.
+class RepositoryTopic
+  @@separator = ":"
+
+  attr_reader :value
+
+  def initialize(text, prefix = "")
+    clean_text = text.to_s.gsub(/[^a-z0-9\-\s]/i, "").downcase.gsub(/\s+/, "-")
+    @value = prefix.nil? || prefix.empty? ? clean_text : "#{prefix}#{@@separator}#{clean_text}"
+  end
+
+  def add_to_repo(repo)
+    puts "==> Adding topic #{@value} to repo..."
+    edit_repo(repo, "add")
+  end
+
+  def remove_from_repo(repo)
+    puts "==> Removing topic #{@value} from repo..."
+    edit_repo(repo, "remove")
+  end
+
+  private
+
+  def edit_repo(repo, action)
+    if dry_run?
+      puts "... -- Dry run mode, no repo edits taking place --"
+    else
+      `gh repo edit #{repo} --#{action}-topic #{@value}`
     end
   end
 end

--- a/mirror-wordpress-plugins
+++ b/mirror-wordpress-plugins
@@ -17,6 +17,15 @@ end
 class WordPressPluginApiError < PluginUpdateError
 end
 
+# Could retrieve API information but it included an error.
+class WordPressPluginJSONContainsError < PluginUpdateError
+  attr_reader :reason
+  def initialize(msg = "Error from wordpress.org", reason = "")
+    @reason = reason
+    super(msg)
+  end
+end
+
 # Could not download a .zip file for a given plugin.
 class WordPressPluginDownloadError < PluginUpdateError
 end
@@ -146,7 +155,7 @@ class Plugin
       raise WordPressPluginApiError, e.message
     end
     # Whippet Racetrack error message here was "No plugin info available for <plugin>".
-    raise WordPressPluginApiError, plugin_info["error"].to_s if plugin_info.key?("error")
+    raise WordPressPluginJSONContainsError.new(plugin_info["error"].to_s, plugin_info["reason"].to_s) if plugin_info.key?("error")
 
     latest_version_no_spaces = plugin_info["version"].tr(" ", "-").to_s
     latest_wordpress_version = latest_version_no_spaces.start_with?("v") ? latest_version_no_spaces : "v#{latest_version_no_spaces}"
@@ -231,6 +240,10 @@ class PluginLibraryUpdater
       rescue WordPressPluginApiError => e
         @failed_updates[plugin.slug] =
           e.message.empty? ? "wordpress.org does not have a plugin called #{plugin.slug}" : e.message
+        next plugin
+      rescue WordPressPluginJSONContainsError => e
+        @failed_updates[plugin.slug] =
+          e.message.empty? ? "wordpress.org reported an error #{plugin.slug}" : "#{e.message} #{e.reason}"
         next plugin
       end
       if !plugin.repos_need_updating?

--- a/mirror-wordpress-plugins
+++ b/mirror-wordpress-plugins
@@ -243,7 +243,7 @@ class RepositoryTopic
   private
 
   def edit_repo(repo, action)
-    if dry_run?
+    if dry_run? && !force_annotation?
       puts "... -- Dry run mode, no repo edits taking place --"
     else
       `gh repo edit #{repo} --#{action}-topic #{@value}`
@@ -385,6 +385,10 @@ end
 
 def force_update?
   ENV["FORCE_UPDATE"] == "true"
+end
+
+def force_annotation?
+  ENV["FORCE_ANNOTATION"] == "true"
 end
 
 puts "==> -- Dry run mode --" if dry_run?

--- a/mirror-wordpress-plugins
+++ b/mirror-wordpress-plugins
@@ -56,6 +56,10 @@ class PluginUpdater
     @tmp_plugin_dir = File.join(Dir.pwd, "tmp", @slug)
   end
 
+  def self.skip_mirror_topic
+    @@skip_mirror_topic
+  end
+
   def fetch_api_information
     @latest_github_version = fetch_latest_github_version
     @latest_wordpress_version, @wordpress_download_link = fetch_latest_wordpress_info
@@ -300,7 +304,7 @@ class PluginLibraryUpdater
       hrule
       puts "==> Checking status of #{plugin.slug}..."
       begin
-        if plugin.topics.include? "skip-mirror" && !annotate_skipped_repos?
+        if plugin.topics.include?(PluginUpdater.skip_mirror_topic) && !annotate_skipped_repos?
           @skipped_plugins.push(plugin.slug)
           puts "==> Skipping..."
           next
@@ -321,7 +325,7 @@ class PluginLibraryUpdater
       end
       puts "...mirroring to it now"
       begin
-        plugin.update_github_mirror unless plugin.topics.include? "skip-mirror"
+        plugin.update_github_mirror unless plugin.topics.include? PluginUpdater.skip_mirror_topic
         @updated_plugins[plugin.slug] = plugin.latest_wordpress_version
       rescue PluginUpdateError => e
         @failed_updates[plugin.slug] = e.message

--- a/mirror-wordpress-plugins
+++ b/mirror-wordpress-plugins
@@ -62,7 +62,7 @@ class PluginUpdater
 
   def fetch_api_information
     @latest_github_version = fetch_latest_github_version
-    @latest_wordpress_version, @wordpress_download_link = fetch_latest_wordpress_info
+    @latest_wordpress_version, @wordpress_download_link = fetch_latest_wordpress_info_and_annotate_repo
     @zip_file = "#{@full_path_to_clone}-#{@latest_wordpress_version}.zip"
   end
 
@@ -167,7 +167,7 @@ class PluginUpdater
     "v#{latest_github_version.strip}"
   end
 
-  def fetch_latest_wordpress_info
+  def fetch_latest_wordpress_info_and_annotate_repo
     puts("==> Querying api.wordpress.org for latest version ...")
     api_info = `curl -s #{@wordpress_api_url}`
     raise WordPressPluginApiError, "No WordPress API info available for #{@slug}" if api_info.nil?
@@ -177,10 +177,8 @@ class PluginUpdater
     rescue JSON::ParserError => e
       raise WordPressPluginApiError, e.message
     end
+    annotate_repo_with_wordpress_metadata(plugin_info)
     if plugin_info.key?("error")
-      annotate_github_mirror(@@skip_mirror_topic)
-      annotate_github_mirror(plugin_info["error"], "status")
-      annotate_github_mirror(plugin_info["reason"], "reason") if plugin_info.key?("reason") && plugin_info["reason"].is_a?(String)
       # Whippet Racetrack error message here was "No plugin info available for <plugin>".
       raise WordPressPluginJSONContainsError.new(plugin_info["error"].to_s, plugin_info["reason"].to_s)
     end
@@ -188,6 +186,14 @@ class PluginUpdater
     latest_version_no_spaces = plugin_info["version"].tr(" ", "-").to_s
     latest_wordpress_version = latest_version_no_spaces.start_with?("v") ? latest_version_no_spaces : "v#{latest_version_no_spaces}"
     [latest_wordpress_version.strip, plugin_info["download_link"]]
+  end
+
+  def annotate_repo_with_wordpress_metadata(plugin_info)
+    if plugin_info.key?("error")
+      annotate_github_mirror(@@skip_mirror_topic)
+      annotate_github_mirror(plugin_info["error"], "status")
+      annotate_github_mirror(plugin_info["reason"], "reason") if plugin_info.key?("reason") && plugin_info["reason"].is_a?(String)
+    end
   end
 
   def download_wordpress_zip(zip_file)


### PR DESCRIPTION
This PR changes the way we deal with failures from the wordpress.org API. Previously, we raised an exception and carried on. Now, we "annotate" the plugin by adding repository topics that explain why the plugin is not available on wordpress.org and the `skip-mirror` topic, so that we don't try to update from WordPress again.

Repo topics are of the form:

* `status:<string>` for error messages, e.g. `status:closed` or `status:plugin-not-found`
* `reason:<string>` for the `reason` key in JSON, e.g. `reason:security-issue`, `reason:merged-into-core`, etc.

The intention here is that prefixes are unique, i.e. each repository should have only one `status` or `reason` topic set, and any old topics of the same "type" are removed before adding a new one.

Later on, this convention will help us add topics like `installs:N` to say how many times we have installed each plugin.

Setting repository topics also allows us to run a search for all plugins that were closed for a particular reason.

We also add two new environment variables for convenience:

* `ANNOTATE_SKIPPED_REPOS` allows repos that already have the `skip-mirror` topic set to be tagged. The current repos that have this were tagged by hand, and so will only get `status` and `reason` topics with this env var set.
* `FORCE_ANNOTATION` ensures that the script adds and removes repository topics even in `dry-run` mode, so that tagging can be de-coupled from pushing to repositories.

The intention is for these env vars to be set when the script is run manually, so they are always `false` in the GitHub actions and example `.env` file.

This PR also contains some refactoring commits, so it might be easier to review commit-by-commit.

## Testing

Make sure you have a .env that matches the _new_ `.env.wordpress-example` and that `DRY_RUN` is set to true, and the new env vars are set to false, then run:

```shell
./mirror-wordpress-plugins --dry-run
```

You might also want to comment out the lines in the `Plugin.cleanup` method so that you can see the tags and commits that the script created.
