### PR TITLE
Topics are separated by a hyphen

### DIFF
--- a/mirror-wordpress-plugins
+++ b/mirror-wordpress-plugins
@@ -231,7 +231,7 @@ end
 # These are not documented and not in a consistent format. So, we remove
 # any punctuation and replace spacing with dashes before storing the string.
 class RepositoryTopic
-  @@separator = ":".freeze
+  @@separator = "-".freeze
 
   attr_reader :value, :repo
 


### PR DESCRIPTION
Unlike in GitLab, where ':' and '::' are commonly
used as label separators, GitHub only allows characters in the range [A-Za-z0-9\-] in topics.

This commit changes the colon separator to a hyphen. It does not change the 'skip-mirror' topic.

See:
https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/classifying-your-repository-with-topics

## Testing

I don't think much is needed here. A dry-run of the script won't catch this error because the dry-run doesn't actually set a topic. If you want to see the error message, manually setting a topic for this repo will trigger it.