### PR TITLE
FIX default branch name passed to PluginUpdater

### DIFF
--- a/mirror-wordpress-plugins
+++ b/mirror-wordpress-plugins
@@ -274,7 +274,7 @@ class PluginUpdaterBuilder
     projects.each do |project|
       json_topics = project["repositoryTopics"]
       topics = json_topics.nil? ? [] : json_topics.map { |hash| hash["name"] }
-      plugin = PluginUpdater.new(project["name"], project["url"], project["defaultBranchRef"], topics)
+      plugin = PluginUpdater.new(project["name"], project["url"], project["defaultBranchRef"]["name"], topics)
       next project if plugin.nil?
       @plugins.push(plugin)
     end


### PR DESCRIPTION
This is not a string in the data we get back from GitHub, it's an associative array, so we need to index the value we want to pass to the PluginUpdater instance.