### PR TITLE
Push code changes and tags separately

### DIFF
--- a/mirror-wordpress-plugins
+++ b/mirror-wordpress-plugins
@@ -122,7 +122,8 @@ class PluginUpdater
     if dry_run?
       puts "... -- Dry run mode, no repo pushing taking place --"
     else
-      `git -C #{@full_path_to_clone} push --tags`
+      `git -C #{@full_path_to_clone} push`
+      `git -C #{@full_path_to_clone} push --tags --force`
       raise GitError, "Could not push to #{@github_url}" unless $CHILD_STATUS.success?
     end
     cleanup


### PR DESCRIPTION
'git push --tags' only pushes tags, not commits and in this case we also need to push tags with force, to overwrite major version tags (e.g. 'v1'). So, this commit separates the two calls to 'git push'.