### PR TITLE
Allow re-tagging of current version on force update

### DIFF
--- a/mirror-wordpress-plugins
+++ b/mirror-wordpress-plugins
@@ -151,7 +151,7 @@ class PluginUpdater
     split_tag = @latest_wordpress_version.split(".")
     major_tag = split_tag[0]
     major_tag.prepend("v") unless major_tag.start_with?("v")
-    `git -C #{@full_path_to_clone} tag #{@latest_wordpress_version}`
+    force_update? ? `git -C #{@full_path_to_clone} tag -f #{@latest_wordpress_version}` : `git -C #{@full_path_to_clone} tag #{@latest_wordpress_version}`
     raise GitError, "Could not create tag #{@latest_wordpress_version}" unless $CHILD_STATUS.success?
     `git -C #{@full_path_to_clone} tag -f #{major_tag}`
   end


### PR DESCRIPTION
Before: if the script was run with `FORCE_UPDATE` set to true, the `commit_and_tag` method would fail when attempting to apply the tag for the current version, because that tag already exists. At this point, the update process for the plugin in question would stop, with the effect that no major version tag would be applied, even if no major version tag previously existed.

Now: if `FORCE_UPDATE` is set to true, we add `-f` to the tag command for the current main version tag, to prevent this error. It would probably be safe to always do this, regardless of whether `FORCE_UPDATE` is set or not, but as a precaution I'm only running it when that is set to true.

## How to test

1. Checkout out `main`, and with `DRY_RUN` and `FORCE_UPDATE` set to true in your local .env file, run the `./mirror-wordpress-plugins`. You should see a `fatal: tag '[current-version]' already exists` error for every plugin
2. Checkout this branch and run `./mirror-wordpress-plugins`. Each repo should be successfully tagged (but not pushed, because we're in dry-run mode).