### PR TITLE
Feature/separate major version tagging script

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,5 @@ FORCE_UPDATE=false
 FORCE_ANNOTATION=false
 # Set repository topics on repositories that already have the 'skip-mirror' topic set, rather than ignoring them.
 ANNOTATE_SKIPPED_REPOS=false
+# Boolean to indicate dry run mode for major version tag script
+TAGGER_DRY_RUN=true

--- a/.env.example
+++ b/.env.example
@@ -18,3 +18,5 @@ FORCE_ANNOTATION=false
 ANNOTATE_SKIPPED_REPOS=false
 # Boolean to indicate dry run mode for major version tag script
 TAGGER_DRY_RUN=true
+# Boolean to force major version tagging of all repos, regardless of when they were last updated. Can be used if e.g. we wish to add major version tags to repos that have not been recently synced. Should generally be set to false, or removed altogether
+TAGGER_FORCE_UPDATE=false

--- a/.env.example
+++ b/.env.example
@@ -9,14 +9,14 @@ GH_ACCOUNT_USERNAME=github-account-username
 # The access token for the GitHub account used to push to GitHub (needs repo & read:org access)
 GH_ACCOUNT_TOKEN=github-account-token
 # Boolean to indicate dry_run mode for local dev use - remove or set to false in prod
-DRY_RUN=true
+DRY_RUN_MIRROR=true
 # Boolean to force all repos to re-sync, regardless of whether they are already fully mirrored. Can be used if e.g. we wish to add additional tags during the mirror process. Should generally be set to false, or removed altogether
-FORCE_UPDATE=false
+FORCE_UPDATE_MIRROR=false
 # Edit repository topics, even in dry-run mode. Use to manage repo metadata when not actually pushing to repos.
 FORCE_ANNOTATION=false
 # Set repository topics on repositories that already have the 'skip-mirror' topic set, rather than ignoring them.
 ANNOTATE_SKIPPED_REPOS=false
 # Boolean to indicate dry run mode for major version tag script
-TAGGER_DRY_RUN=true
+DRY_RUN_TAGGER=true
 # Boolean to force major version tagging of all repos, regardless of when they were last updated. Can be used if e.g. we wish to add major version tags to repos that have not been recently synced. Should generally be set to false, or removed altogether
-TAGGER_FORCE_UPDATE=false
+FORCE_UPDATE_TAGGER=false

--- a/.github/workflows/wordpress-mirror.yml
+++ b/.github/workflows/wordpress-mirror.yml
@@ -40,8 +40,8 @@ jobs:
           GH_ACCOUNT_USERNAME: ${{ secrets.GH_ACCOUNT_USERNAME }}
           GH_ACCOUNT_TOKEN: ${{ secrets.GH_ACCOUNT_TOKEN }}
           GH_ORG_NAME: ${{ secrets.GH_ORG_NAME }}
-          DRY_RUN: ${{ secrets.DRY_RUN }}
-          FORCE_UPDATE: ${{ secrets.FORCE_UPDATE }}
+          DRY_RUN_MIRROR: ${{ secrets.DRY_RUN_MIRROR }}
+          FORCE_UPDATE_MIRROR: ${{ secrets.FORCE_UPDATE_MIRROR }}
           FORCE_ANNOTATION: ${{ secrets.FORCE_ANNOTATION }}
           ANNOTATE_SKIPPED_REPOS: ${{ secrets.ANNOTATE_SKIPPED_REPOS }}
         run: |

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Install act:
 brew install act
 ```
 
-Then copy the `.env.example` file to `.env`, and populate it with the appropriate values (you can use the values from the service accounts in 1password if needed). In particular, set `DRY_RUN=true`, so that no real changes are made.
+Then copy the `.env.example` file to `.env`, and populate it with the appropriate values (you can use the values from the service accounts in 1password if needed). In particular, set `DRY_RUN_MIRROR=true`, so that no real changes are made.
 
 Then run the action with:
 
@@ -39,7 +39,7 @@ If you're using a machine with an ARM-based processor, you may need to do:
 act -j mirror-gitlab-plugins --secret-file .env --container-architecture linux/amd64
 ```
 
-NOTE: if you don't set `DRY_RUN=true`, this will actually start the mirroring process off for real, and there are over 700 plugins to be mirrored! If you mean to do this (e.g. to test against a small batch of real data) you may want to tweak lines 58 & 60 of the `mirror-plugins` script to reduce that number, e.g.:
+NOTE: if you don't set `DRY_RUN_MIRROR=true`, this will actually start the mirroring process off for real, and there are over 700 plugins to be mirrored! If you mean to do this (e.g. to test against a small batch of real data) you may want to tweak lines 58 & 60 of the `mirror-plugins` script to reduce that number, e.g.:
 
 ```
 projects = Gitlab.group_projects(ENV['GITLAB_WORDPRESS_PLUGINS_GROUP_ID'], per_page: 10)

--- a/apply-major-version-tags
+++ b/apply-major-version-tags
@@ -88,7 +88,7 @@ class Plugin
     puts("==> Querying GitHub for latest version ...")
     latest_github_version = `gh api repos/#{ENV.fetch("GH_ORG_NAME")}/#{@slug}/git/refs/tags --jq '.[].ref' | cut -d '/' -f 3 | grep -Eo "[0-9\.]+" | sort -V | tail -n 1`
     # Assume the repo is empty and/or does not have any tags.
-    return "" unless $CHILD_STATUS.success?
+    return "" unless $CHILD_STATUS.success? && latest_github_version.strip != "."
     "v#{latest_github_version.strip}"
   end
 end

--- a/apply-major-version-tags
+++ b/apply-major-version-tags
@@ -203,7 +203,7 @@ class PluginLibraryTagger
 end
 
 def dry_run?
-  ENV["DRY_RUN"] == "true"
+  ENV["TAGGER_DRY_RUN"] == "true"
 end
 
 puts "==> -- Dry run mode --" if dry_run?

--- a/apply-major-version-tags
+++ b/apply-major-version-tags
@@ -107,8 +107,10 @@ class PluginCollection
     projects = JSON.parse(plugin_library_repos)
     puts "==> Found #{projects.size} plugins in the library"
     projects.each do |project|
-      updated_date_time = Time.parse(project["updatedAt"])
-      next project if (Time.now - updated_date_time) > @@last_updated_range
+      unless force_update?
+        updated_date_time = Time.parse(project["updatedAt"])
+        next project if (Time.now - updated_date_time) > @@last_updated_range
+      end
       plugin = Plugin.new(project["name"], project["url"])
       next project if plugin.nil?
       # puts project["name"]
@@ -206,7 +208,13 @@ def dry_run?
   ENV["TAGGER_DRY_RUN"] == "true"
 end
 
+def force_update?
+  ENV["TAGGER_FORCE_UPDATE"] == "true"
+end
+
 puts "==> -- Dry run mode --" if dry_run?
+
+puts "==> -- Force update mode --" if force_update?
 
 tagger = PluginLibraryTagger.new
 tagger.update

--- a/apply-major-version-tags
+++ b/apply-major-version-tags
@@ -1,0 +1,213 @@
+#!/usr/bin/env ruby
+
+require "bundler/setup"
+require "dotenv"
+require "English"
+require "json"
+require "rubygems"
+require "time"
+require "zip"
+
+Dotenv.load
+
+# Generic error class, can be caught but should not be raised.
+class PluginUpdateError < StandardError
+end
+
+# Could not find a latest version tag for the plugin
+class MissingVersionError < PluginUpdateError
+end
+
+# Could not perform Git action on repo. Only useful for interacting with remotes.
+class GitError < PluginUpdateError
+end
+
+# A Plugin is a representation of a GitHub repository that mirrors a
+# plugin from wordpress.org. Plugins are responsible for updating
+# their related repositories.
+class Plugin
+  attr_reader :slug, :repo, :github_url, :full_path_to_clone, :latest_github_version, :latest_major_version
+
+  def initialize(name, github_url)
+    @slug = name
+    @repo = "#{ENV.fetch("GH_ORG_NAME")}/#{@slug}"
+    @github_url = github_url
+    @github_https_url = "#{@github_url}.git"
+    @full_path_to_clone = File.join(Dir.pwd, @slug)
+    @tmp_plugin_dir = File.join(Dir.pwd, "tmp", @slug)
+  end
+
+  def populate_version_information
+    @latest_github_version = fetch_latest_github_version
+    raise MissingVersionError, "No version tags found for #{slug}" if @latest_github_version == ""
+    split_tag = @latest_github_version.split(".")
+    major_tag = split_tag[0]
+    major_tag.prepend("v") unless major_tag.start_with?("v")
+    @latest_major_version = major_tag
+  end
+
+  def update_major_version_tag
+    puts "==> Cloning the #{@slug} GitHub repo..."
+    `git clone #{construct_github_https_url} #{@full_path_to_clone}`
+    raise GitError, "Could not clone #{@github_url}" unless $CHILD_STATUS.success?
+
+    puts "==> Tagging the repo with the latest major version tag..."
+    tag
+    `git -C #{@full_path_to_clone} status`
+    puts "==> Updating the GitHub repo..."
+    if dry_run?
+      puts "... -- Dry run mode, no repo pushing taking place --"
+    else
+      puts "!!! ERROR This should not be running"
+      # `git -C #{@full_path_to_clone} push --tags --force`
+      # raise GitError, "Could not push to #{@github_url}" unless $CHILD_STATUS.success?
+    end
+    cleanup
+  end
+
+  def cleanup
+    puts "==> Cleaning up downloaded files..."
+    `rm -rf #{@zip_file}`
+    `rm -rf #{@full_path_to_clone}`
+    `rm -rf #{@tmp_files_for_plugin}`
+  end
+
+  private
+
+  def construct_github_https_url
+    credentials = ENV.fetch("GH_ACCOUNT_USERNAME") + ":" + ENV.fetch("GH_ACCOUNT_TOKEN") + "@"
+    url = "https://github.com/" + ENV.fetch("GH_ORG_NAME") + "/" + @slug + ".git"
+    url.insert(8, credentials)
+  end
+
+  def tag
+    `git -C #{@full_path_to_clone} tag -f #{@latest_major_version} #{@latest_github_version}`
+  end
+
+  def fetch_latest_github_version
+    puts("==> Querying GitHub for latest version ...")
+    latest_github_version = `gh api repos/#{ENV.fetch("GH_ORG_NAME")}/#{@slug}/git/refs/tags --jq '.[].ref' | cut -d '/' -f 3 | grep -Eo "[0-9\.]+" | sort -V | tail -n 1`
+    # Assume the repo is empty and/or does not have any tags.
+    return "" unless $CHILD_STATUS.success?
+    "v#{latest_github_version.strip}"
+  end
+end
+
+# Get information about organisation plugins from GitHub and transform into an
+# array of Plugin objects.
+class PluginCollection
+  @@max_repos_in_library = 99_999 # Effectively unlimited.
+  @@last_updated_range = 43_200 # 12 hours in seconds - we're going to run this more frequently than the actual mirroring, so this should be plenty
+
+  def initialize
+    @plugins = []
+  end
+
+  def build
+    projects = JSON.parse(plugin_library_repos)
+    puts "==> Found #{projects.size} plugins in the library"
+    projects.each do |project|
+      updated_date_time = Time.parse(project["updatedAt"])
+      next project if (Time.now - updated_date_time) > @@last_updated_range
+      plugin = Plugin.new(project["name"], project["url"])
+      next project if plugin.nil?
+      # puts project["name"]
+      @plugins.push(plugin)
+    end
+    @plugins
+  end
+
+  private
+
+  def plugin_library_repos
+    puts "==> Fetching all GitHub plugin repositories in the library..."
+    `gh repo list #{ENV.fetch("GH_ORG_NAME")} --limit=#{@@max_repos_in_library} --json=name,url,updatedAt --no-archived`
+  end
+end
+
+# Update all repositories in a GitHub organisation, assuming each one has been
+# mirrored from wordpress.org. Optionally print a summary of the updates
+# that have been performed or have errored.
+class PluginLibraryTagger
+  def initialize
+    @failed_updates = {}
+    @updated_plugins = {}
+    @start_time = nil
+    @end_time = nil
+  end
+
+  def update
+    @start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    plugins = PluginCollection.new.build
+    plugins.each do |plugin|
+      hrule
+      puts "==> Checking status of #{plugin.slug}..."
+      begin
+        plugin.populate_version_information
+      rescue MissingVersionError => e
+        @failed_updates[plugin.slug] =
+          e.message.empty? ? "error retrieving version tags for #{plugin.slug}" : e.message.to_s
+        next plugin
+      end
+      puts "...applying major tag to it now"
+      begin
+        plugin.update_major_version_tag
+        @updated_plugins[plugin.slug] = {
+          major_tag: plugin.latest_major_version,
+          corresponding_version: plugin.latest_github_version
+        }
+      rescue PluginUpdateError => e
+        @failed_updates[plugin.slug] = e.message
+        plugin.cleanup
+      end
+    end
+    @end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+  end
+
+  def print_summary
+    print_updated_plugin_summary
+    print_failed_plugin_summary
+    hrule
+    elapsed_time = @end_time - @start_time
+    puts "==> Mirroring plugins took: #{(elapsed_time / 60).round}m#{(elapsed_time % 60).round}s."
+  end
+
+  private
+
+  def print_updated_plugin_summary
+    return if @updated_plugins.empty?
+
+    hrule
+    puts "==> Updated the following #{@updated_plugins.size} plugin(s):"
+    @updated_plugins.each do |name, version_hash|
+      puts "#{name} #{version_hash[:corresponding_version]} tagged as #{version_hash[:major_tag]}"
+    end
+  end
+
+  def print_failed_plugin_summary
+    return if @failed_updates.empty?
+
+    hrule
+    puts "==> Failed to update the following #{@failed_updates.size} plugin(s):"
+    @failed_updates.each do |name, error_message|
+      puts
+      puts "*** #{name} failed to update with message:"
+      puts error_message
+    end
+  end
+
+  def hrule
+    puts
+    puts "-----------------------------------------------------------------------"
+  end
+end
+
+def dry_run?
+  ENV["DRY_RUN"] == "true"
+end
+
+puts "==> -- Dry run mode --" if dry_run?
+
+tagger = PluginLibraryTagger.new
+tagger.update
+tagger.print_summary

--- a/apply-major-version-tags
+++ b/apply-major-version-tags
@@ -205,11 +205,11 @@ class PluginLibraryTagger
 end
 
 def dry_run?
-  ENV["TAGGER_DRY_RUN"] == "true"
+  ENV["DRY_RUN_TAGGER"] == "true"
 end
 
 def force_update?
-  ENV["TAGGER_FORCE_UPDATE"] == "true"
+  ENV["FORCE_UPDATE_TAGGER"] == "true"
 end
 
 puts "==> -- Dry run mode --" if dry_run?

--- a/mirror-plugins
+++ b/mirror-plugins
@@ -74,11 +74,11 @@ class Plugin
 end
 
 def dry_run?
-  ENV["DRY_RUN"] == "true"
+  ENV["DRY_RUN_MIRROR"] == "true"
 end
 
 def force_update?
-  ENV["FORCE_UPDATE"] == "true"
+  ENV["FORCE_UPDATE_MIRROR"] == "true"
 end
 
 Gitlab.configure do |config|

--- a/mirror-wordpress-plugins
+++ b/mirror-wordpress-plugins
@@ -388,7 +388,7 @@ class PluginLibraryUpdater
 end
 
 def dry_run?
-  ENV["DRY_RUN"] == "true"
+  ENV["DRY_RUN_MIRROR"] == "true"
 end
 
 def annotate_skipped_repos?
@@ -396,7 +396,7 @@ def annotate_skipped_repos?
 end
 
 def force_update?
-  ENV["FORCE_UPDATE"] == "true"
+  ENV["FORCE_UPDATE_MIRROR"] == "true"
 end
 
 def force_annotation?


### PR DESCRIPTION
This PR adds an initial version of the script to apply major version tags to all projects in this org, independently from the `mirror-wordpress-plugins` script. The intention is that major version tagging will be removed from the mirror script in a future plugin when this script is fully activated, so that the two can run separately. This will allow us to automatically generate major version tags for plugins that are manually updated, as well as those that are mirrored from WordPress.

The script checks which repos in this org have been updated in the past 12 hours, and then applies major version tags to those. The major version tag is based on the highest full semver tag currently applied to the repo in question, and the major version tag is then applied to the same commit that the full semver tag points to (rather than to the HEAD commit of the default branch). This should ensure that, in the unlikely event that the repo is updated with a new major version while this script is running, we don't accidentally end up with the incorrect major version tag pointing at the new major version.

Given that we'll be running this script on a schedule more than once every 12 hours, the logic will result in us re-applying major version tags to repos that already have them correctly applied. However, no changes will actually result from this, so it should be safe to take this approach.

Currently, the script is set up so that even if it is accidentally run in non-dry-run mode, it will not push anything to GitHub.

## How to test

1. Populate you local `.env` file based on `.env.example`. Set `TAGGER_DRY_RUN` to `true`, and `TAGGER_FORCE_UPDATE` to false.
2. Run the script: `./apply-major-version-tags`. You should get an output along the lines of:
   ```
   ==> Updated the following 3 plugin(s):
   cookie-law-info v3.2.5 tagged as v3
   mappress-google-maps-for-wordpress v2.92.1 tagged as v2
   wpdatatables v3.4.2.20 tagged as v3
   ```
   (Depending on which plugins were updated in the past 12 hours).