### PR TITLE
Rename example .env files

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,25 +2,17 @@
 # To run the script or action locally, rename this file to .env
 # Then populate it with the relevant values
 
-# The URL for the GitLab API endpoint
-GITLAB_API_ENDPOINT=https://git.govpress.com/api/v4
-# The numeric GitLab group ID that all the WordPress plugins you want to mirror are held in
-GITLAB_WORDPRESS_PLUGINS_GROUP_ID=71
 # The name of the GitHub org you want to mirror to
 GH_ORG_NAME=dxw-wordpress-plugins
-# The default branch for the plugin repos in GitLab
-DEFAULT_BRANCH_NAME=master
-# The ID of the GitHub team you want to give read access to the GitHub repos (obtainable via GitHub API)
-GH_TEAM_ID=1234567
 # The username for the GitHub account used to push to GitHub (a service account will be used for this in prod)
 GH_ACCOUNT_USERNAME=github-account-username
 # The access token for the GitHub account used to push to GitHub (needs repo & read:org access)
 GH_ACCOUNT_TOKEN=github-account-token
-# The username for the GitLab account used to clone from GitLab (a service account will be used for this in prod)
-GITLAB_ACCOUNT_USERNAME=gitlab-account-username
-# The access token for the GitLab account used to clone from GitLab (needs read api & read repo access)
-GITLAB_ACCOUNT_TOKEN=gitlab-account-token
 # Boolean to indicate dry_run mode for local dev use - remove or set to false in prod
 DRY_RUN=true
 # Boolean to force all repos to re-sync, regardless of whether they are already fully mirrored. Can be used if e.g. we wish to add additional tags during the mirror process. Should generally be set to false, or removed altogether
 FORCE_UPDATE=false
+# Edit repository topics, even in dry-run mode. Use to manage repo metadata when not actually pushing to repos.
+FORCE_ANNOTATION=false
+# Set repository topics on repositories that already have the 'skip-mirror' topic set, rather than ignoring them.
+ANNOTATE_SKIPPED_REPOS=false

--- a/.env.gitlab.example
+++ b/.env.gitlab.example
@@ -2,17 +2,25 @@
 # To run the script or action locally, rename this file to .env
 # Then populate it with the relevant values
 
+# The URL for the GitLab API endpoint
+GITLAB_API_ENDPOINT=https://git.govpress.com/api/v4
+# The numeric GitLab group ID that all the WordPress plugins you want to mirror are held in
+GITLAB_WORDPRESS_PLUGINS_GROUP_ID=71
 # The name of the GitHub org you want to mirror to
 GH_ORG_NAME=dxw-wordpress-plugins
+# The default branch for the plugin repos in GitLab
+DEFAULT_BRANCH_NAME=master
+# The ID of the GitHub team you want to give read access to the GitHub repos (obtainable via GitHub API)
+GH_TEAM_ID=1234567
 # The username for the GitHub account used to push to GitHub (a service account will be used for this in prod)
 GH_ACCOUNT_USERNAME=github-account-username
 # The access token for the GitHub account used to push to GitHub (needs repo & read:org access)
 GH_ACCOUNT_TOKEN=github-account-token
+# The username for the GitLab account used to clone from GitLab (a service account will be used for this in prod)
+GITLAB_ACCOUNT_USERNAME=gitlab-account-username
+# The access token for the GitLab account used to clone from GitLab (needs read api & read repo access)
+GITLAB_ACCOUNT_TOKEN=gitlab-account-token
 # Boolean to indicate dry_run mode for local dev use - remove or set to false in prod
 DRY_RUN=true
 # Boolean to force all repos to re-sync, regardless of whether they are already fully mirrored. Can be used if e.g. we wish to add additional tags during the mirror process. Should generally be set to false, or removed altogether
 FORCE_UPDATE=false
-# Edit repository topics, even in dry-run mode. Use to manage repo metadata when not actually pushing to repos.
-FORCE_ANNOTATION=false
-# Set repository topics on repositories that already have the 'skip-mirror' topic set, rather than ignoring them.
-ANNOTATE_SKIPPED_REPOS=false


### PR DESCRIPTION
Previously `.env.example` applied to the GitLab->GitHub mirror, which we no longer use, and `.env.wordpress.example` applied to the new WordPress->GitHub mirror. Now that the WordPress mirror runs as default, it makes sense to swap the names over.