### PR TITLE
Fix/avoid blank reason topics

### DIFF
--- a/mirror-wordpress-plugins
+++ b/mirror-wordpress-plugins
@@ -83,7 +83,7 @@ class PluginUpdater
   def annotate_github_mirror(value, prefix = "")
     new_topic = RepositoryTopic.new(value, @repo, prefix)
     if @topics.include? new_topic.value
-      puts "==> @slug already has a #{new_topic.value} topic set"
+      puts "==> #{@slug} already has a #{new_topic.value} topic set"
     end
     if !prefix.empty?
       @topics.each do |topic|

--- a/mirror-wordpress-plugins
+++ b/mirror-wordpress-plugins
@@ -186,11 +186,11 @@ class PluginUpdater
   end
 
   def annotate_repo_with_wordpress_metadata(plugin_info)
-    if plugin_info.key?("error")
-      annotate_github_mirror(@@skip_mirror_topic)
-      annotate_github_mirror(plugin_info["error"], "status")
-      annotate_github_mirror(plugin_info["reason"], "reason") if plugin_info.key?("reason") && plugin_info["reason"].is_a?(String)
-    end
+    return unless plugin_info.key?("error")
+
+    annotate_github_mirror(@@skip_mirror_topic)
+    annotate_github_mirror(plugin_info["error"], "status")
+    annotate_github_mirror(plugin_info["reason"], "reason") if plugin_info.key?("reason") && plugin_info["reason"].is_a?(String) && !plugin_info["reason"].empty?
   end
 
   def download_wordpress_zip(zip_file)


### PR DESCRIPTION
The JSON we get from WordPress will offer a reason why plugins have been closed or removed from the upstream library. However, sometimes the reason is an empty string and previously that led to a small number (24) plugins in our library being given a 'reason-' topic.

This commit makes the relevant method a little more defensive and does not set the topic if 'reason' is an empty string in the JSON.

We also make the method a little more Ruby-ish by removing some lexical scope with the 'return/unless' pattern.

There's also a small fix in this PR for some logging code that was treating a variable like a string.

## Manual fixes

Once this is merged, I will delete the `reason-` topic from the remaining repos.

## Testing

In your `.env` file make sure that you have `ANNOTATE_SKIPPED_REPOS=true` and `DRY_RUN` set to `true`.

We had (!) 24 repos with a `reason-` topic set, but I deleted the topic from:

* https://github.com/dxw-wordpress-plugins/you-can-javascript
* https://github.com/dxw-wordpress-plugins/share-and-follow
* https://github.com/dxw-wordpress-plugins/cforms

and possibly a couple of others, you can see the remaining repos with the problematic topic here:

https://github.com/orgs/dxw-wordpress-plugins/repositories?language=&q=topic%3Areason-&sort=&type=all

Run the mirror script with something like:

```shell
./mirror-wordpress-plugins | tee results.txt
```

so that you can easily search the output, then once it's finished look for the plugins above and check there is no `reason-` topic set, e.g.:

```shell
❯ grep cforms results.txt
==> Checking status of cforms...
==> cforms already has a skip-mirror topic set
==> cforms already has a status-closed topic set
==> Checking status of cforms-tests...
==> cforms-tests already has a skip-mirror topic set
==> cforms-tests already has a status-plugin-not-found topic set
```