### PR TITLE
Add scheduled workflow for major-version-tagger script

### DIFF
--- a/.github/workflows/tagger.yml
+++ b/.github/workflows/tagger.yml
@@ -1,0 +1,62 @@
+name: Apply major version tags to plugin repos on GitHub
+
+on:
+  workflow_dispatch: 
+  schedule:
+    - cron: '0 */2 * * *'  # Runs every 2 hours
+
+jobs:
+  mirror-wordpress-plugins:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Ruby setup
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+
+      - name: install GitHub CLI for local testing
+        if: ${{ env.ACT }}
+        run: |
+          curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo gpg --dearmor -o /usr/share/keyrings/githubcli-archive-keyring.gpg
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+          sudo apt update
+          sudo apt install gh
+
+      - name: Authenticate with GitHub CLI
+        run: |
+          echo "${{ secrets.GH_ACCOUNT_TOKEN }}" | gh auth login --with-token
+
+      - name: Add global Git configuration
+        run: |
+          git config --global user.email "team+govpress-tools@govpress.com"
+          git config --global user.name "WordPress plugin mirror robot"
+
+      - name: Apply major version tags
+        env:
+          GH_ACCOUNT_USERNAME: ${{ secrets.GH_ACCOUNT_USERNAME }}
+          GH_ACCOUNT_TOKEN: ${{ secrets.GH_ACCOUNT_TOKEN }}
+          GH_ORG_NAME: ${{ secrets.GH_ORG_NAME }}
+          DRY_RUN_TAGGER: ${{ secrets.DRY_RUN_TAGGER }}
+          FORCE_UPDATE_TAGGER: ${{ secrets.FORCE_UPDATE_TAGGER }}
+        run: |
+          ./apply-major-version-tags
+
+      - name: Keep workflow alive
+        uses: gautamkrishnar/keepalive-workflow@2.0.1
+        with:
+          commit_message: Automated commit by Keepalive Workflow to keep the repository active [skip ci]
+          committer_username: dxw-govpress-tools
+          committer_email: team+govpress-tools@govpress.com
+
+      - name: Alert Slack if failure
+        if: ${{ failure() }}
+        uses: slackapi/slack-github-action@v1.23.0
+        with:
+          channel-id: ${{ secrets.SLACK_CHANNEL_ID }}  # Slack channel id to post message
+          slack-message: "The scheduled task to apply major tags to GitHub plugin repos [EXPERIMENTAL BRANCH] has failed. Check the workflow history for more information: https://github.com/dxw-wordpress-plugins/mirror-gitlab-plugins/actions/workflows/tagger.yml, and see the documentation for possible causes: https://github.com/dxw-wordpress-plugins/mirror-gitlab-plugins/blob/main/README.md"
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
This workflow will run the major version tagger every 2 hours. This greater frequency than the mirroring should ensure we always catch any plugins that need tagging.

Currently the tagging script will always run in a dry-run state (even if `DRY_RUN_TAGGER` isn't set), so this will just allow us to keep an eye on it and check it runs consistently without errors.