### PR TITLE
Disable scheduled mirror runs

### DIFF
--- a/.github/workflows/wordpress-mirror.yml
+++ b/.github/workflows/wordpress-mirror.yml
@@ -2,8 +2,6 @@ name: Mirror WordPress plugins to GitHub
 
 on:
   workflow_dispatch: 
-  schedule:
-    - cron: '0 8,12,16 * * *'  # Runs at 08:00, 12:00, and 16:00 UTC
 
 jobs:
   mirror-wordpress-plugins:


### PR DESCRIPTION
We've got a bug in the mirroring from WordPress. Until it's fixed, it'll be easier to not run the mirroring task.

I've left the workflow_dispatch option there, so we can manually trigger the workflow if we want to.