### PR TITLE
FIX incorrect file copying to Git clones

### DIFF
--- a/mirror-wordpress-plugins
+++ b/mirror-wordpress-plugins
@@ -52,7 +52,6 @@ class PluginUpdater
     @topics = topics
     @full_path_to_clone = File.join(Dir.pwd, @slug)
     @wordpress_api_url = "#{@@wordpress_api_url}#{@slug.downcase}.json"
-    @tmp_plugin_dir = File.join(Dir.pwd, "tmp", @slug)
   end
 
   def self.skip_mirror_topic
@@ -104,17 +103,16 @@ class PluginUpdater
     raise WordPressPluginApiError, "No download link available for #{@slug}" if @wordpress_download_link.nil?
 
     download_wordpress_zip(@zip_file)
-    # We expect to overwrite files in the cloned repository here, as per the
-    # instructions for updating pro plugins manually. However, rubyzip doesn't
-    # like to overwrite existing files, so we unzip first then move.
-    FileUtils.mkdir_p(@tmp_plugin_dir)
-    extract_zip(@zip_file, @tmp_plugin_dir)
-    Dir.glob(File.join(@tmp_plugin_dir, "**", "*"), File::FNM_DOTMATCH).each do |file|
-      next if [".", ".."].include?(File.basename(file))
+    # Delete existing files in the repo
+    puts "==> Deleting existing files in the repo"
+    files = Dir.glob(File.join(@full_path_to_clone, "**", "*"), File::FNM_DOTMATCH)
+    files.each do |file|
+      next if File.directory?(file) || file.include?(".git")
 
-      destination_path = File.join(@full_path_to_clone, File.basename(file))
-      FileUtils.mv(file, destination_path, force: true)
+      FileUtils.rm(file)
     end
+    # Then unzip into the Git directory
+    extract_zip(@zip_file, Dir.pwd)
     puts "==> Committing and tagging the repo with full tag..."
     commit_and_tag
     `git -C #{@full_path_to_clone} status`


### PR DESCRIPTION
Previously the code to extract zip files from wordpress.org and copy them to the Git clone from GitHub was based on the PHP code from Whippet racetrack. There were some modifications to work around the way the rubyzip library worked, which meant that we unzipped the archive in a temporary folder and then moved the files over to the Git clone.

This code contained a bug which meant that sometimes the directory structure in the archive was not the same as the directory structure in the clone. Some repos had extra directories added which contained the top-level files and otherse seemed to have directories removed.

This commit fixes that by replacing the old way of committing to the clone with the manual process we use for pro-plugins. Here, we clone the plugin repo from the library, delete the existing files (except the .git folder) and unzip the archive into the clone. Then we commit, tag and push to the plugin repository.