### PR TITLE
Revert "Disable scheduled mirror runs"

### DIFF
--- a/.github/workflows/wordpress-mirror.yml
+++ b/.github/workflows/wordpress-mirror.yml
@@ -2,6 +2,8 @@ name: Mirror WordPress plugins to GitHub
 
 on:
   workflow_dispatch: 
+  schedule:
+    - cron: '0 8,12,16 * * *'  # Runs at 08:00, 12:00, and 16:00 UTC
 
 jobs:
   mirror-wordpress-plugins:


### PR DESCRIPTION
This reverts commit ba1a1e62bb47daa3c9a78bc7bd9b122d85e0aed7, which temporarily removed the scheduled task to mirror WordPress plugins from wordpress.org while we fixed it. That is now done, so it can be reinstated.