### PR TITLE
FIX version discovery for empty GitHub repos

### DIFF
--- a/mirror-wordpress-plugins
+++ b/mirror-wordpress-plugins
@@ -154,6 +154,7 @@ class PluginUpdater
     puts("==> Querying GitHub for latest version ...")
     latest_github_version = `gh api repos/#{ENV.fetch("GH_ORG_NAME")}/#{@slug}/git/refs/tags --jq '.[].ref' | cut -d '/' -f 3 | grep -Eo "[0-9\.]+" | sort -V | tail -n 1`
     # Assume the repo is empty and/or does not have any tags.
+    return "" if latest_github_version.strip == "."
     return "" unless $CHILD_STATUS.success?
     "v#{latest_github_version.strip}"
   end


### PR DESCRIPTION
Previously, we assumed that if 'gh' and 'jq' could not find any version information from a GitHub plugin repo then the shell command would exit with a non-zero exit code.

In practice, we have found (with the 'loco-translate' plugin) that the shell exec writes some text to stderr and exit with status 0. However, it returns the string '.\n'.

In this commit we check for that string that is returned by 'jq' and if that is the result of the shell exec we return an empty string, indicating that the repo had no tags.

This is important because when we mirror an entirely new plugin, we do so from a completely empty repository.

## Original error

```shell
==> Fetching all GitHub plugin repositories in the library...
==> Found 786 plugins in the library

-----------------------------------------------------------------------
==> Checking status of loco-translate...
==> Querying GitHub for latest version ...
gh: Git Repository is empty. (HTTP 409)
==> Querying api.wordpress.org for latest version ...
/opt/hostedtoolcache/Ruby/2.7.2/x64/lib/ruby/2.7.0/rubygems/version.rb:2[15](https://github.com/dxw-wordpress-plugins/mirror-gitlab-plugins/actions/runs/10144439030/job/28047924851#step:7:16):in `initialize': Malformed version number string . (ArgumentError)
	from /opt/hostedtoolcache/Ruby/2.7.2/x64/lib/ruby/2.7.0/rubygems/version.rb:206:in `new'
	from /opt/hostedtoolcache/Ruby/2.7.2/x64/lib/ruby/2.7.0/rubygems/version.rb:206:in `new'
	from ./mirror-wordpress-plugins:78:in `repos_need_updating?'
	from ./mirror-wordpress-plugins:3[20](https://github.com/dxw-wordpress-plugins/mirror-gitlab-plugins/actions/runs/10144439030/job/28047924851#step:7:21):in `block in update'
	from ./mirror-wordpress-plugins:301:in `each'
	from ./mirror-wordpress-plugins:301:in `update'
	from ./mirror-wordpress-plugins:403:in `<main>'
==> loco-translate is v2.6.11 on WordPress and v. on GitHub
```


https://github.com/dxw-wordpress-plugins/mirror-gitlab-plugins/actions/runs/10144439030/job/28047924851

## Testing


1. Clone this repo
2. Copy `.env.example` to `.env` 
3. Make sure that all `DRY_RUN_...` variables are `true` and all `FORCE_...` variables are `false`
4. Create a new GitHub PAT token or use the one in 1Password under `GovPress tools service account` ... `mirror-gitlab-plugins` and add it to the appropriate variable in your `.env` file
5. Optionally, comment out lines 132-134 in the `cleanup` method in `mirror-wordpress-plugins` so that you can check tags and so on in the "mirrored" repos
6. From the `main` branch run `./mirror-wordpress-plugins --dry-run` and check that `loco-translate` fails to mirror with an error message
7. Checkout this branch and run the script again. Check that `loco-translate` is mirrored
8. If you commented out lines 132-134 go into the new `loco-translate` directory and check there is a Git commit and a Git tag 