### PR TITLE
Ignore checksums in Markdown changelog files

### DIFF
--- a/lib/plugin_verifier.rb
+++ b/lib/plugin_verifier.rb
@@ -17,8 +17,9 @@ class PluginVerifier
   # Gruntfile.js from simple-lightbox
   # README.md from Widget-CSS-Classes
   @@ignored_files = ["readme", "readme.txt", "readme.md", "readme.html", "changelog",
-    "changelog.txt", "Gruntfile.js", ".gitattributes", ".gitignore", ".git", "composer.json",
-    "composer.lock", "package.json", "package.lock", "phpcs.xml.dist"]
+    "changelog.md", "changelog.txt", "Gruntfile.js", ".gitattributes", ".gitignore",
+    ".git", "composer.json", "composer.lock", "package.json", "package.lock",
+    "phpcs.xml.dist"]
   # geo-my-wp v4.5.2
   @@ignored_exts = [".mo", ".po"]
   # geo-my-wp v4.5.2 and v4.5.3


### PR DESCRIPTION
Due to this failure this morning:

```
==> Failed to update the following 1 plugin(s):

*** instagram-feed failed to update with message:
CHANGELOG.md checksum mismatch. File does not exist in GitHub repository.
```