### PR TITLE
Populate empty variable before sending to Slack

### DIFF
--- a/.github/workflows/wordpress-mirror.yml
+++ b/.github/workflows/wordpress-mirror.yml
@@ -52,7 +52,8 @@ jobs:
           echo "DEBUG: Messages captured:"
           echo "$COULD_NOT_MIRROR"
           echo "DEBUG: Length: ${#COULD_NOT_MIRROR}"
-          if [ -n "$COULD_NOT_MIRROR" ] ; then
+          if [ -n "$COULD_NOT_MIRROR" ]; then
+            if [[ -z "$COULD_NOT_MIRROR" ]]; then $COULD_NOT_MIRROR=":shrug:"; fi
             echo "messages=$COULD_NOT_MIRROR" >> $GITHUB_OUTPUT
             echo 'ALERT_SLACK=1' >> $GITHUB_ENV
           fi


### PR DESCRIPTION
If $COULD_NOT_MIRROR exists, but is empty, the slack message will fail.

```
Error: failed to match all allowed schemas [json-pointer:/blocks/2/text]
Error: must be more than 0 characters [json-pointer:/blocks/2/text/text]
```

So we should ensure that it's not empty.